### PR TITLE
Allow usage of generate_core outside of source directory

### DIFF
--- a/htfft/stage_gen.py
+++ b/htfft/stage_gen.py
@@ -3,8 +3,7 @@ import os
 import jinja2
 from fusesoc.capi2.generator import Generator
 
-from htfft import helper, conversions
-import htfft_gen
+from htfft import helper, conversions, htfft_gen
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Without this patch, the htfft_gen source is not found.